### PR TITLE
Make recreate_columns function public

### DIFF
--- a/salvattore.js
+++ b/salvattore.js
@@ -258,7 +258,8 @@
     return {
       append_elements: append_elements,
       prepend_elements: prepend_elements,
-      register_grid: register_grid
+      register_grid: register_grid,
+      recreate_columns: recreate_columns
     };
   });
 


### PR DESCRIPTION
Sometimes is useful to recreate the columns after some changes. I've put this function public.
