### PR TITLE
Make sure rule.selectorText exists before doing the regular expression

### DIFF
--- a/salvattore.js
+++ b/salvattore.js
@@ -136,7 +136,7 @@
       i = rules.length;
       while (i--) {
         rule = rules[i];
-        if (rule.selectorText.match(/\[data-columns\](.*)::?before$/)) {
+        if (rule.selectorText && rule.selectorText.match(/\[data-columns\](.*)::?before$/)) {
           return true;
         }
       }


### PR DESCRIPTION
Firefox throws this error when trying to load salvattore from requirejs:
[14:49:36.421] TypeError: rule.selectorText is undefined @ http://127.0.0.1:3000/js/vendor/salvattore.js:139

This fix makes sure rule.selectorText is defined before running a regular expression on it.
