### PR TITLE
Fix chrome canary error in salvattore example

### DIFF
--- a/examples/salvattore.css
+++ b/examples/salvattore.css
@@ -20,7 +20,15 @@
 
 /* Be sure to hide the element containing the configuration */
 [data-columns]::before {
-    display: none;
+    visibility: hidden;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
 }
 
 /* Configurate salvattore with media queries */


### PR DESCRIPTION
If the 'display' of [data-columns] is set to 'none' the content value of the before element is empty. This leads to an error. Fix done by making it visually hidden. Change to documentary necessary also, not done here.
This references #40 and maybe #38 too.
