### PR TITLE
ie 11 DocumentFragment .children undefined, use .childNodes instead

### DIFF
--- a/src/salvattore.js
+++ b/src/salvattore.js
@@ -216,7 +216,7 @@ self.next_element_column_index = function next_element_column_index(grid, fragme
   ;
   for (i = 0; i < m; i++) {
     child = children[i];
-    currentRowCount = child.children.length + fragments[i].children.length;
+    currentRowCount = child.children.length + (fragments[i].children || fragments[i].childNodes).length;
   if(lowestRowCount === 0) {
     lowestRowCount = currentRowCount;
   }


### PR DESCRIPTION
ie 11 DocumentFragment doesn't have .children field, use .childNodes instead
fragments[i].children was undefined when using iexplore 11.0.9600.16521
This happens only when appending items to the list
