### PR TITLE
append_elements: using Array.prototype.forEach over elements object

### DIFF
--- a/src/salvattore.js
+++ b/src/salvattore.js
@@ -254,7 +254,7 @@ self.append_elements = function append_elements(grid, elements) {
     , fragments = self.create_list_of_fragments(numberOfColumns)
   ;
 
-  elements.forEach(function append_to_next_fragment(element) {
+  Array.prototype.forEach.call(elements, function append_to_next_fragment(element) {
     var columnIndex = self.next_element_column_index(grid, fragments);
     fragments[columnIndex].appendChild(element);
   });


### PR DESCRIPTION
Intended to address [Issue #115](https://github.com/rnmp/salvattore/issues/115) details of the fix in [my comment here](https://github.com/rnmp/salvattore/issues/115).

I ran the default grunt task but it looks like there were some changes from a previous commit that hadn't yet been built, so I'll just leave it as is for now.

I haven't tested this fix thoroughly, but it solves the issues that were seen with Infinite Scroll. As I said in the comment for the issue, I may of missed the point entirely, I'm open to that possibility :)
