### PR TITLE
Fix incorrect function call in appendElements

### DIFF
--- a/src/salvattore.js
+++ b/src/salvattore.js
@@ -260,7 +260,7 @@ self.appendElements = function appendElements(grid, elements) {
   ;
 
   Array.prototype.forEach.call(elements, function append_to_next_fragment(element) {
-    var columnIndex = self.next_element_column_index(grid, fragments);
+    var columnIndex = self.nextElementColumnIndex(grid, fragments);
     fragments[columnIndex].appendChild(element);
   });
 


### PR DESCRIPTION
First off, thank you for open-sourcing and maintaining salvatorre.js. Its been really useful for me! :beers: 

I was encountering an error in the current version, when trying to call `appendElements`. After digging into it, it looks like its trying to invoke `next_element_column_index`, which doesn't exist:

![screen shot on 2014-12-01 at 16_56_58](https://cloud.githubusercontent.com/assets/896486/5254965/ae96dd16-797b-11e4-82b6-139cab2b9687.png)

I've changed the function call to match the function name already defined.

Thanks!
