### PR TITLE
Wait for DOMContentLoaded event before calling self.init

### DIFF
--- a/src/salvattore.js
+++ b/src/salvattore.js
@@ -384,7 +384,7 @@ self.init = function init() {
   self.scanMediaQueries();
 };
 
-self.init();
+document.addEventListener('DOMContentLoaded', self.init);
 
 return {
   appendElements: self.appendElements,


### PR DESCRIPTION
Hi,

I had trouble running salvattore. Googling for "salvattore not working" I found http://stackoverflow.com/questions/27120109/salvattore-does-not-work 

This problem can easily be avoided by running self.init() only after the DOM has loaded. This works for IE9+.

At least for me this change was useful, so I thought you might want to consider this. ;)

Cheers,
Maxime